### PR TITLE
Rename visual-based graph labels to chart

### DIFF
--- a/src/Classes/BasicClass.js
+++ b/src/Classes/BasicClass.js
@@ -24,8 +24,8 @@ import relativeNode from '../AddFunctionality/relativeNode.js';
 import addAnimation from '../AddFunctionality/animate.js';
 
 export default class BasicClass {
-  constructor(graphArray, input) {
-    this.createGraph = {
+  constructor(chartArray, input) {
+    this.createChart = {
       BAR: createBarChart,
       BUBBLE: createBubbleChart,
       SCATTER: createScatterPlot,
@@ -60,14 +60,14 @@ export default class BasicClass {
       BOX: 'box-plot',
     };
     this.svgTypeMap = svgTypeMap;
-    this.graphArray = graphArray;
+    this.chartArray = chartArray;
     this.options = input.options;
     this.data = input.data;
     this.input = input; // probably don't need this
 
-    this.iterateGraphs = () => {
-      for (let i = 0; i < this.graphArray.length; i++) {
-        this.options[i].chartClass = svgTypeMap[this.graphArray[i]];
+    this.iterateCharts = () => {
+      for (let i = 0; i < this.chartArray.length; i++) {
+        this.options[i].chartClass = svgTypeMap[this.chartArray[i]];
 
         this.selector = input.selector ? input.selector : '#chart';
 
@@ -91,25 +91,25 @@ export default class BasicClass {
         // general elements is an object that contains the svg, x and y, and the xAxis and yAxis
         let generalElements;
         if (this.options[i].stack && i === 0 && !this.options[0].updating) {
-          generalElements = createAxes(this.input.data[i], graphArray[i], this.options[i]);
-          generalElements.svg = createSVG(this.selector, graphArray[i], this.options[i]);
+          generalElements = createAxes(this.input.data[i], chartArray[i], this.options[i]);
+          generalElements.svg = createSVG(this.selector, chartArray[i], this.options[i]);
           this.generalElements = generalElements;
         } else if (!this.options[i].stack && !this.options[0].updating) {
-          generalElements = createAxes(this.input.data[i], graphArray[i], this.options[i]);
-          generalElements.svg = createSVG(this.selector, graphArray[i], this.options[i]);
+          generalElements = createAxes(this.input.data[i], chartArray[i], this.options[i]);
+          generalElements.svg = createSVG(this.selector, chartArray[i], this.options[i]);
           this.generalElements = generalElements;
         } else if (this.options[0].updating) {
-          generalElements = createAxes(this.input.data[i], graphArray[i], this.options[i]);
+          generalElements = createAxes(this.input.data[i], chartArray[i], this.options[i]);
           this.generalElements = generalElements;
         }
         if (!this.options[0].updating) {
-          this.createGraph[this.graphArray[i]](this.data[i], this.options[i], this.generalElements);
+          this.createChart[this.chartArray[i]](this.data[i], this.options[i], this.generalElements);
         }
         // get rid of this
         const options = this.options[i];
 
         // This is where we add the class and opacity option to the data elements
-        const elements = d3.selectAll(`svg.${svgTypeMap[this.graphArray[i]]} circle, arc, rect, path, line, polygon, node`);
+        const elements = d3.selectAll(`svg.${svgTypeMap[this.chartArray[i]]} circle, arc, rect, path, line, polygon, node`);
         // eslint-disable-next-line no-loop-func
         elements.each(function () {
           const element = d3.select(this);
@@ -133,20 +133,20 @@ export default class BasicClass {
         }
 
         if (this.options[i].animate || this.options[0].updating) {
-          addAnimation(this.selector, this.createGraph[this.graphArray[i]], this.data[i], this.options[i], this.generalElements);
+          addAnimation(this.selector, this.createChart[this.chartArray[i]], this.data[i], this.options[i], this.generalElements);
         } else {
-          appendAxes(this.graphArray[i], this.options[i], this.generalElements);
+          appendAxes(this.chartArray[i], this.options[i], this.generalElements);
         }
       }
     };
-    this.iterateGraphs();
+    this.iterateCharts();
   }
 
-  addGraphs(type) { // This method probably needs to be refactored
-    this.graphArray.push(...type);
+  addCharts(type) { // This method probably needs to be refactored
+    this.chartArray.push(...type);
     for (let i = 0; i < type.length; i++) {
-      this.createGraph[type[i]](this.data, this.options, this.generalElements);
-      appendAxes(this.graphArray[i], this.options, this.generalElements);
+      this.createChart[type[i]](this.data, this.options, this.generalElements);
+      appendAxes(this.chartArray[i], this.options, this.generalElements);
     }
   }
 
@@ -181,6 +181,6 @@ export default class BasicClass {
       this.options = input.options;
     }
 
-    this.iterateGraphs();
+    this.iterateCharts();
   }
 }

--- a/src/Classes/GeographicClass.js
+++ b/src/Classes/GeographicClass.js
@@ -2,22 +2,22 @@ import onHover from '../AddFunctionality/onHover.js';
 import relativeNode from '../AddFunctionality/relativeNode.js';
 
 export default class GeographicClass {
-  constructor(graphArray, input) {
-    this.createGraph = {
-    
+  constructor(chartArray, input) {
+    this.createChart = {
+
     };
     const svgTypeMap = {
-    
+
     };
 
-    this.graphArray = graphArray;
+    this.chartArray = chartArray;
     this.options = input.options;
     this.data = input.data;
     this.input = input;
 
-    this.iterateGraphs = () => {
-      for (let i = 0; i < this.graphArray.length; i++) {
-        this.options[i].chartClass = svgTypeMap[this.graphArray[i]];
+    this.iterateCharts = () => {
+      for (let i = 0; i < this.chartArray.length; i++) {
+        this.options[i].chartClass = svgTypeMap[this.chartArray[i]];
 
         this.selector = input.selector ? input.selector : '#chart';
 
@@ -39,25 +39,25 @@ export default class GeographicClass {
         }
         let generalElements;
         if (this.options[i].stack && i === 0) {
-          generalElements = createAxes(this.input.data[i], graphArray[i], this.options[i]);
-          generalElements.svg = createSVG(this.selector, graphArray[i], this.options[i]);
+          generalElements = createAxes(this.input.data[i], chartArray[i], this.options[i]);
+          generalElements.svg = createSVG(this.selector, chartArray[i], this.options[i]);
           this.generalElements = generalElements;
         } else if (!this.options[i].stack) {
-          generalElements = createAxes(this.input.data[i], graphArray[i], this.options[i]);
-          generalElements.svg = createSVG(this.selector, graphArray[i], this.options[i]);
+          generalElements = createAxes(this.input.data[i], chartArray[i], this.options[i]);
+          generalElements.svg = createSVG(this.selector, chartArray[i], this.options[i]);
           this.generalElements = generalElements;
         }
-        console.log(this.options[i], 'options', this.graphArray[i], 'graph', this.data[i], 'data', this.selector, 'selector')
-        this.createGraph[this.graphArray[i]](this.data[i], this.options[i], this.generalElements);
+        console.log(this.options[i], 'options', this.chartArray[i], 'graph', this.data[i], 'data', this.selector, 'selector');
+        this.createChart[this.chartArray[i]](this.data[i], this.options[i], this.generalElements);
         const options = this.options[i];
-        const elements = d3.selectAll(`svg.${svgTypeMap[this.graphArray[i]]} circle, arc, rect, path, line, polygon, node`);
+        const elements = d3.selectAll(`svg.${svgTypeMap[this.chartArray[i]]} circle, arc, rect, path, line, polygon, node`);
         // eslint-disable-next-line no-loop-func
         elements.each(function () {
           const element = d3.select(this);
           const { classList } = this; // Access the classList property of the DOM element
 
           if (classList.length === 0) {
-           // The element has no classes, you can assign a class here
+            // The element has no classes, you can assign a class here
             element.classed(`${options.chartClass}${i}`, true);
           }
           if (options.opacity) {
@@ -72,17 +72,17 @@ export default class GeographicClass {
           relativeNode(this.selector, this.data[i], this.options[i]);
         }
 
-        appendAxes(this.graphArray[i], this.options[i], this.generalElements);
+        appendAxes(this.chartArray[i], this.options[i], this.generalElements);
       }
     };
-    this.iterateGraphs();
+    this.iterateCharts();
   }
 
-  addGraphs(type) {
-    this.graphArray.push(...type);
+  addCharts(type) {
+    this.chartArray.push(...type);
     for (let i = 0; i < type.length; i++) {
-      this.createGraph[type[i]](this.data, this.options, this.generalElements);
-      appendAxes(this.graphArray[i], this.options, this.generalElements);
+      this.createChart[type[i]](this.data, this.options, this.generalElements);
+      appendAxes(this.chartArray[i], this.options, this.generalElements);
     }
   }
 
@@ -114,6 +114,6 @@ export default class GeographicClass {
       this.options = input.options;
     }
 
-    this.iterateGraphs();
+    this.iterateCharts();
   }
 }

--- a/src/Classes/HierarchyClass.js
+++ b/src/Classes/HierarchyClass.js
@@ -12,10 +12,9 @@ import createAdjacencyMatrix from '../Charts/hierarchicalCharts/adjacencyMatrix.
 import createDendrogram from '../Charts/hierarchicalCharts/dendogram.js';
 import createRadialTree from '../Charts/hierarchicalCharts/radialTreeMap.js';
 
-
 export default class HierarchyClass {
-  constructor(graphArray, input) {
-    this.graphArray = graphArray;
+  constructor(chartArray, input) {
+    this.chartArray = chartArray;
     this.input = input;
     this.input.data = input.data;
     this.input.selector = input.selector ? input.selector : '#chart';
@@ -34,7 +33,7 @@ export default class HierarchyClass {
       this.input.options = input.options;
     }
 
-    this.createGraph = {
+    this.createChart = {
       SUNBURST: createSunburstChart,
       TREEMAP: createTreeMap,
       TREEDIAGRAM: createTreeDiagram,
@@ -47,26 +46,26 @@ export default class HierarchyClass {
       ADJACENCY: createAdjacencyMatrix,
       DENDROGRAM: createDendrogram,
       RADIALTREE: createRadialTree,
-      
+
     };
 
-    this.iterateGraphs = () => {
-      for (let i = 0; i < this.graphArray.length; i++) {
+    this.iterateCharts = () => {
+      for (let i = 0; i < this.chartArray.length; i++) {
         console.log(this.input.data[i], this.input.selector, this.input.options[i]);
-        this.createGraph[this.graphArray[i]](this.input.data[i], this.input.selector, this.input.options[i]);
+        this.createChart[this.chartArray[i]](this.input.data[i], this.input.selector, this.input.options[i]);
       }
     };
 
-    this.iterateGraphs();
+    this.iterateCharts();
   }
 
-  addGraphs(type) {
-    this.graphArray.push(...type);
+  addCharts(type) {
+    this.chartArray.push(...type);
     if (!Array.isArray(type)) {
-      this.createGraph[type](this.input.data, this.input.selector, this.input.options);
+      this.createChart[type](this.input.data, this.input.selector, this.input.options);
     } else {
       for (let i = 0; i < type.length; i++) {
-        this.createGraph[type[i]](this.input.data, this.input.selector, this.input.options);
+        this.createChart[type[i]](this.input.data, this.input.selector, this.input.options);
       }
     }
   }
@@ -103,6 +102,6 @@ export default class HierarchyClass {
       this.input.options = input.options;
     }
 
-    this.iterateGraphs();
+    this.iterateCharts();
   }
 }

--- a/src/Classes/classFunctions/appendAxes.js
+++ b/src/Classes/classFunctions/appendAxes.js
@@ -1,4 +1,4 @@
-export default function appendAxes(graph, options, generalElements) {
+export default function appendAxes(chart, options, generalElements) {
   const { width } = options;
   const { height } = options;
   const { margin } = options;
@@ -6,8 +6,8 @@ export default function appendAxes(graph, options, generalElements) {
   const { xAxis } = generalElements;
   const { yAxis } = generalElements;
   // this will be checked by grpah tags in the future
-  if (graph === 'POLAR' || graph === 'RADAR' || graph === 'PIE' || graph === 'DONUT' || graph === 'HEATMAP' || graph === 'BUBBLE') return;
-  if (graph === 'BAR') {
+  if (chart === 'POLAR' || chart === 'RADAR' || chart === 'PIE' || chart === 'DONUT' || chart === 'HEATMAP' || chart === 'BUBBLE') return;
+  if (chart === 'BAR') {
     svg.append('g')
       .classed('x-axis', true)
       .call(xAxis)
@@ -28,7 +28,7 @@ export default function appendAxes(graph, options, generalElements) {
       .attr('text-anchor', 'end')
       .attr('transform', 'rotate(-90)')
       .text(options.y);
-  } else if (graph === 'STACKEDBAR') {
+  } else if (chart === 'STACKEDBAR') {
     svg.append('g')
       .classed('x-axis', true)
       .attr('transform', `translate(0,${height - margin.bottom})`)

--- a/src/Classes/classFunctions/createSVG.js
+++ b/src/Classes/classFunctions/createSVG.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 
-export default function createSVG(selector, graph, options) {
+export default function createSVG(selector, chart, options) {
   let svg;
 
   if (options.stack) {
@@ -15,13 +15,13 @@ export default function createSVG(selector, graph, options) {
       .attr('width', options.width)
       .attr('height', options.height);
 
-    if (graph === 'PIE' || graph === 'DONUT' || graph === 'GAUGE' || graph === 'POLAR' || graph === 'RADAR') {
+    if (chart === 'PIE' || chart === 'DONUT' || chart === 'GAUGE' || chart === 'POLAR' || chart === 'RADAR') {
       svg.classed(`${options.chartClass}`, true);
-      console.log('SVG', svg)
+      console.log('SVG', svg);
       const g = svg.append('g')
         .attr('transform', `translate(${options.width / 2}, ${options.height / 2})`);
 
-      if (graph === 'DONUT') {
+      if (chart === 'DONUT') {
         svg.attr('viewBox', `0 0 ${options.width} ${options.height}`);
       }
 
@@ -43,7 +43,7 @@ export default function createSVG(selector, graph, options) {
     }
     return svg;
   }
-  if (graph === 'PIE' || graph === 'DONUT' || graph === 'GAUGE' || graph === 'POLAR' || graph === 'RADAR') {
+  if (chart === 'PIE' || chart === 'DONUT' || chart === 'GAUGE' || chart === 'POLAR' || chart === 'RADAR') {
     svg = d3.select(selector)
       .append('svg')
       .classed(`${options.chartClass}`, true)
@@ -52,9 +52,9 @@ export default function createSVG(selector, graph, options) {
       .append('g')
       .attr('transform', `translate(${options.width / 2}, ${options.height / 2})`);
 
-    if (graph === 'DONUT') {
+    if (chart === 'DONUT') {
       svg.attr('viewBox', `0 0 ${options.width} ${options.height}`);
-    } else if (graph === 'BUBBLE') {
+    } else if (chart === 'BUBBLE') {
       svg = d3.select(selector)
         .append('svg')
         .classed('bubble-chart', true)

--- a/src/Classes/classFunctions/createXY.js
+++ b/src/Classes/classFunctions/createXY.js
@@ -1,9 +1,9 @@
 import { createXAxisLine, createYAxisLine } from './axisLines';
 
-export default function generalElementsFunction(data, graph, options) {
+export default function generalElementsFunction(data, chart, options) {
   let x;
 
-  switch (graph) {
+  switch (chart) {
     case 'BAR':
     case 'BOX':
       data.sort((a, b) => d3.ascending(a.x, b.x));
@@ -65,7 +65,7 @@ export default function generalElementsFunction(data, graph, options) {
       .range([options.height - options.margin.bottom, options.margin.top]),
   };
 
-  const y = (scaleFunctions[graph] || scaleFunctions.default)();
+  const y = (scaleFunctions[chart] || scaleFunctions.default)();
   const xAxisPosition = options.xAxisPosition || (options.height - options.margin.bottom);
   const yAxisPosition = options.yAxisPosition || options.margin.left;
   const xAxis = (g) => {
@@ -75,7 +75,7 @@ export default function generalElementsFunction(data, graph, options) {
   };
 
   let yAxis;
-  switch (graph) {
+  switch (chart) {
     case 'WATERFALL':
       yAxis = (g) => g
         .attr('transform', `translate(${yAxisPosition},0)`)
@@ -94,7 +94,7 @@ export default function generalElementsFunction(data, graph, options) {
     default:
       yAxis = (g) => g
         .attr('transform', `translate(${yAxisPosition},0)`)
-        .call(d3.axisLeft(y).ticks(graph === 'STACKEDBAR' ? null : options.height / 80))
+        .call(d3.axisLeft(y).ticks(chart === 'STACKEDBAR' ? null : options.height / 80))
         .call((g) => {
           if (options.yLine) { // may be able to get rid of this
             createYAxisLine(g, options, xAxisPosition);


### PR DESCRIPTION
This PR is a proposed change to rename visual `graphs` to `charts`. It is based on an earlier conversation of the term _graphs_ being used for data structures and _charts_ for visual representations. A potential edge case is a graph chart.

### Notes:

addGraphs (now addCharts) does not currently appear to be utilized in the repo, but I changed the label for consistency.