### PR TITLE
Globally rename generalElements to chartComponents

### DIFF
--- a/__tests__/BasicCharts/AreaChart.test.js
+++ b/__tests__/BasicCharts/AreaChart.test.js
@@ -46,9 +46,9 @@ describe('createD3AreaChart', () => {
 
   test('creates an SVG element', () => {
     const { document } = jsdom.window;
-    const generalElements = AXES('AREA', document.querySelector('#chart'), options);
-    generalElements.svg = SVG('AREA', document.querySelector('#chart'), options);
-    createD3AreaChart(data, document.querySelector('#chart'), options, generalElements);
+    const chartComponents = AXES('AREA', document.querySelector('#chart'), options);
+    chartComponents.svg = SVG('AREA', document.querySelector('#chart'), options);
+    createD3AreaChart(data, document.querySelector('#chart'), options, chartComponents);
     const svgElement = document.querySelector('#chart svg.area-chart');
     expect(svgElement).not.toBeNull();
   });

--- a/src/oomph-visualizer/d3/actions/animate/basic/animate-area.js
+++ b/src/oomph-visualizer/d3/actions/animate/basic/animate-area.js
@@ -1,9 +1,9 @@
 // animateAreaChart.js
-export default function animateArea(chart, sortedData, generalElements, options, duration) {
+export default function animateArea(chart, sortedData, chartComponents, options, duration) {
   const area = d3.area()
-    .x((d) => generalElements.x(d.x))
+    .x((d) => chartComponents.x(d.x))
     .y0(options.height - options.margin.bottom)
-    .y1((d) => generalElements.y(d.y));
+    .y1((d) => chartComponents.y(d.y));
 
   chart.select('.area-chart0')
     .datum(sortedData)

--- a/src/oomph-visualizer/d3/actions/animate/basic/animate-bar.js
+++ b/src/oomph-visualizer/d3/actions/animate/basic/animate-bar.js
@@ -1,10 +1,10 @@
-export default function animateBar(selection, data, generalElements, options, duration) {
+export default function animateBar(selection, data, chartComponents, options, duration) {
   const { width, margin, barWidth } = options;
   const dynamicBarWidth = ((width - margin.left - margin.right) / data.length) + barWidth;
   selection.transition()
     .duration(duration)
-    .attr('x', (d) => generalElements.x(d.x) - dynamicBarWidth / 2)
-    .attr('y', (d) => generalElements.y(d.y))
-    .attr('height', (d) => generalElements.y(0) - generalElements.y(d.y))
+    .attr('x', (d) => chartComponents.x(d.x) - dynamicBarWidth / 2)
+    .attr('y', (d) => chartComponents.y(d.y))
+    .attr('height', (d) => chartComponents.y(0) - chartComponents.y(d.y))
     .attr('width', dynamicBarWidth);
 }

--- a/src/oomph-visualizer/d3/actions/animate/basic/animate-basic.js
+++ b/src/oomph-visualizer/d3/actions/animate/basic/animate-basic.js
@@ -9,19 +9,19 @@ import animateDonut from './animate-donut';
 import animateFunnel from './animate-funnel';
 import animateStacked from './animate-stacked';
 
-export default function addAnimation(selector, data, options, generalElements, duration = 1000) {
+export default function addAnimation(selector, data, options, chartComponents, duration = 1000) {
   setTimeout(() => {
     const chart = d3.select(selector);
 
     chart.select('.x-axis')
       .transition()
       .duration(duration)
-      .call(generalElements.xAxis);
+      .call(chartComponents.xAxis);
 
     chart.select('.y-axis')
       .transition()
       .duration(duration)
-      .call(generalElements.yAxis);
+      .call(chartComponents.yAxis);
 
     let chartElements = chart.selectAll('g rect, g circle, .line-graph0, .area-chart0, path');
     // if (options.updating) {
@@ -61,21 +61,21 @@ export default function addAnimation(selector, data, options, generalElements, d
     console.log('TYPE', type);
     // Update the area chart separately
     switch (type) {
-      case 'bar-chart0': animateBar(chartElements, data, generalElements, options, duration);
+      case 'bar-chart0': animateBar(chartElements, data, chartComponents, options, duration);
         break;
-      case 'scatter-plot0': animateScatter(chartElements, data, generalElements, duration);
+      case 'scatter-plot0': animateScatter(chartElements, data, chartComponents, duration);
         break;
-      case 'line-graph0': animateLine(chartElements, sortedData, generalElements, duration);
+      case 'line-graph0': animateLine(chartElements, sortedData, chartComponents, duration);
         break;
-      case 'area-chart0': animateArea(chart, sortedData, generalElements, options, duration);
+      case 'area-chart0': animateArea(chart, sortedData, chartComponents, options, duration);
         break;
-      case 'pie-chart0': animatePie(generalElements, data, duration, options);
+      case 'pie-chart0': animatePie(chartComponents, data, duration, options);
         break;
-      case 'donut-chart0': animateDonut(generalElements, data, duration, options);
+      case 'donut-chart0': animateDonut(chartComponents, data, duration, options);
         break;
-      case 'funnel-chart0': animateFunnel(generalElements, data, duration, options);
+      case 'funnel-chart0': animateFunnel(chartComponents, data, duration, options);
         break;
-      case 'stacked-bar-chart0': animateStacked(generalElements, data, duration, options);
+      case 'stacked-bar-chart0': animateStacked(chartComponents, data, duration, options);
         break;
       default: console.log('No animation for this chart type');
     }

--- a/src/oomph-visualizer/d3/actions/animate/basic/animate-donut.js
+++ b/src/oomph-visualizer/d3/actions/animate/basic/animate-donut.js
@@ -1,4 +1,4 @@
-export default function animateDonutChart(generalElements, data, duration, options) {
+export default function animateDonutChart(chartComponents, data, duration, options) {
   const svg = d3.select('svg');
   console.log(svg);
 

--- a/src/oomph-visualizer/d3/actions/animate/basic/animate-funnel.js
+++ b/src/oomph-visualizer/d3/actions/animate/basic/animate-funnel.js
@@ -1,8 +1,8 @@
-// export default function updateD3FunnelChart(generalElements, data, duration, options) {
+// export default function updateD3FunnelChart(chartComponents, data, duration, options) {
 //   const { width } = options;
 //   const { colors } = options;
-//   const { x } = generalElements;
-//   const { y } = generalElements;
+//   const { x } = chartComponents;
+//   const { y } = chartComponents;
 //   const colorScale = d3.scaleOrdinal().domain(data.map((d) => d.x)).range(colors);
 //   const svg = d3.select('svg');
 
@@ -41,11 +41,11 @@
 //     (exit) => exit.remove(),
 //   );
 // }
-// export default function updateD3FunnelChart(generalElements, data, duration, options) {
+// export default function updateD3FunnelChart(chartComponents, data, duration, options) {
 //     const { width } = options;
 //     const { colors } = options;
-//     const { x } = generalElements;
-//     const { y } = generalElements;
+//     const { x } = chartComponents;
+//     const { y } = chartComponents;
 //     const colorScale = d3.scaleOrdinal().domain(data.map((d) => d.x)).range(colors);
 //     const svg = d3.select('svg');
 
@@ -90,11 +90,11 @@
 //       rectsUpdate.exit().remove();
 //     });
 //   }
-export default function updateD3FunnelChart(generalElements, data, duration, options) {
+export default function updateD3FunnelChart(chartComponents, data, duration, options) {
   const { width } = options;
   const { colors } = options;
-  const { x } = generalElements;
-  const { y } = generalElements;
+  const { x } = chartComponents;
+  const { y } = chartComponents;
   const colorScale = d3.scaleOrdinal().domain(data.map((d) => d.x)).range(colors);
   const svg = d3.select('svg');
 

--- a/src/oomph-visualizer/d3/actions/animate/basic/animate-line.js
+++ b/src/oomph-visualizer/d3/actions/animate/basic/animate-line.js
@@ -1,7 +1,7 @@
-export default function animateLine(chartElements, data, generalElements, duration) {
+export default function animateLine(chartElements, data, chartComponents, duration) {
   const line = d3.line()
-    .x((d) => generalElements.x(d.x))
-    .y((d) => generalElements.y(d.y));
+    .x((d) => chartComponents.x(d.x))
+    .y((d) => chartComponents.y(d.y));
 
   // const sortedData = data.slice().sort((a, b) => d3.ascending(a.x, b.x));
 

--- a/src/oomph-visualizer/d3/actions/animate/basic/animate-pie.js
+++ b/src/oomph-visualizer/d3/actions/animate/basic/animate-pie.js
@@ -1,4 +1,4 @@
-export default function animatePie(generalElements, data, duration, options) {
+export default function animatePie(chartComponents, data, duration, options) {
   const svg = d3.select('svg');
   console.log(svg);
 

--- a/src/oomph-visualizer/d3/actions/animate/basic/animate-scatter.js
+++ b/src/oomph-visualizer/d3/actions/animate/basic/animate-scatter.js
@@ -1,4 +1,4 @@
-export default function animateScatter(chartElements, data, generalElements, duration) {
+export default function animateScatter(chartElements, data, chartComponents, duration) {
   const updateSelection = chartElements.data(data);
   const enterSelection = updateSelection.enter();
   const exitSelection = updateSelection.exit();
@@ -14,8 +14,8 @@ export default function animateScatter(chartElements, data, generalElements, dur
     .merge(enterSelection)
     .transition()
     .duration(duration)
-    .attr('cx', (d) => generalElements.x(d.x))
-    .attr('cy', (d) => generalElements.y(d.y));
+    .attr('cx', (d) => chartComponents.x(d.x))
+    .attr('cy', (d) => chartComponents.y(d.y));
 
   // Exit selection
   exitSelection.remove();

--- a/src/oomph-visualizer/d3/actions/animate/basic/animate-stacked.js
+++ b/src/oomph-visualizer/d3/actions/animate/basic/animate-stacked.js
@@ -1,7 +1,7 @@
-export default function createD3StackedBarChart(data, options, generalElements) {
+export default function createD3StackedBarChart(data, options, chartComponents) {
   const {
     x, y, svg,
-  } = generalElements;
+  } = chartComponents;
 
   // Create a color scale using the color scheme provided
   const color = d3.scaleOrdinal()
@@ -29,9 +29,9 @@ export default function createD3StackedBarChart(data, options, generalElements) 
         .attr('y', y(0))
         .attr('height', 0)
         .attr('width', x.bandwidth())
-        .call((enterSelection) => animateBar(enterSelection, data, generalElements, options, options.duration)),
+        .call((enterSelection) => animateBar(enterSelection, data, chartComponents, options, options.duration)),
       (update) => update
-        .call((updateSelection) => animateBar(updateSelection, data, generalElements, options, options.duration)),
+        .call((updateSelection) => animateBar(updateSelection, data, chartComponents, options, options.duration)),
     )
     .transition()
     .duration(options.duration)

--- a/src/oomph-visualizer/d3/actions/stack.js
+++ b/src/oomph-visualizer/d3/actions/stack.js
@@ -43,13 +43,13 @@
 //   });
 // }
 // // createCombinedChart();
-export default function stack(selector, chartConfigs, generalElements) {
+export default function stack(selector, chartConfigs, chartComponents) {
   // const container = createSvgContainer(selector, {
   //   width: 600,
   //   height: 400,
   // });
 
   chartConfigs.forEach((config) => {
-    config.chartFn(config.data, config.generalElements.svg, config.options, generalElements);
+    config.chartFn(config.data, config.chartComponents.svg, config.options, chartComponents);
   });
 }

--- a/src/oomph-visualizer/d3/charts/basic/area.js
+++ b/src/oomph-visualizer/d3/charts/basic/area.js
@@ -1,9 +1,9 @@
-export default function createD3AreaChart(data, options, generalElements) {
+export default function createD3AreaChart(data, options, chartComponents) {
   const { height } = options;
   const { margin } = options;
-  const { x } = generalElements;
-  const { y } = generalElements;
-  const { svg } = generalElements;
+  const { x } = chartComponents;
+  const { y } = chartComponents;
+  const { svg } = chartComponents;
   // Define the area generator function using the x and y scales
   const area = d3.area()
     .x((d) => x(d.x))

--- a/src/oomph-visualizer/d3/charts/basic/bar.js
+++ b/src/oomph-visualizer/d3/charts/basic/bar.js
@@ -1,7 +1,7 @@
-export default function createD3BarChart(data, options, generalElements) {
-  const { x } = generalElements;
-  const { y } = generalElements;
-  const { svg } = generalElements;
+export default function createD3BarChart(data, options, chartComponents) {
+  const { x } = chartComponents;
+  const { y } = chartComponents;
+  const { svg } = chartComponents;
 
   // Sort the data by the x value
   data.sort((a, b) => d3.ascending(a.x, b.x));

--- a/src/oomph-visualizer/d3/charts/basic/box.js
+++ b/src/oomph-visualizer/d3/charts/basic/box.js
@@ -1,11 +1,11 @@
-export default function createD3BoxPlot(data, options, generalElements) {
+export default function createD3BoxPlot(data, options, chartComponents) {
   // TODO try to accept multiple data set shapes, and calculate the mean, median, etc. from the data
   const fillColor = options.fillColor || 'steelblue';
-  const { x } = generalElements;
-  const { y } = generalElements;
-  const { xAxis } = generalElements;
-  const { yAxis } = generalElements;
-  const { svg } = generalElements;
+  const { x } = chartComponents;
+  const { y } = chartComponents;
+  const { xAxis } = chartComponents;
+  const { yAxis } = chartComponents;
+  const { svg } = chartComponents;
 
   function update(data) {
     x.domain(data.map((d) => d.category));

--- a/src/oomph-visualizer/d3/charts/basic/bubble.js
+++ b/src/oomph-visualizer/d3/charts/basic/bubble.js
@@ -1,6 +1,6 @@
-export default function createBubbleChart(data, options, generalElements) {
+export default function createBubbleChart(data, options, chartComponents) {
   const { diameter } = options;
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
   const colorScheme = options.colorScheme || d3.schemeCategory10;
 
   // Prepare the data for the chart

--- a/src/oomph-visualizer/d3/charts/basic/donut.js
+++ b/src/oomph-visualizer/d3/charts/basic/donut.js
@@ -1,6 +1,6 @@
-export default function createD3DonutChart(data, options, generalElements) {
+export default function createD3DonutChart(data, options, chartComponents) {
   const { radius } = options;
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
 
   const chartGroup = svg.append('g')
     .attr('transform', `translate(${options.width / 2}, ${options.height / 2})`);

--- a/src/oomph-visualizer/d3/charts/basic/funnel.js
+++ b/src/oomph-visualizer/d3/charts/basic/funnel.js
@@ -1,9 +1,9 @@
-export default function createD3FunnelChart(data, options, generalElements) {
+export default function createD3FunnelChart(data, options, chartComponents) {
   const { width } = options;
   const { colors } = options;
-  const { x } = generalElements;
-  const { y } = generalElements;
-  const { svg } = generalElements;
+  const { x } = chartComponents;
+  const { y } = chartComponents;
+  const { svg } = chartComponents;
   const colorScale = d3.scaleOrdinal().domain(data.map((d) => d.x)).range(colors);
 
   const funnel = svg

--- a/src/oomph-visualizer/d3/charts/basic/gauge.js
+++ b/src/oomph-visualizer/d3/charts/basic/gauge.js
@@ -74,7 +74,7 @@
 // }
 
 // CODE ABOVE HAS BETTER TRANSITION, try to merge
-export default function createD3GaugeChart(sampleValues, options, generalElements) {
+export default function createD3GaugeChart(sampleValues, options, chartComponents) {
   const width = options.width || 300;
   const height = options.height || 300;
   const radius = Math.min(width, height) / 2;
@@ -86,7 +86,7 @@ export default function createD3GaugeChart(sampleValues, options, generalElement
   const minorTickColor = options.minorTickColor || 'black';
   const pointerColor = options.pointerColor || 'red';
   const arcColors = options.arcColors || d3.schemeCategory10;
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
 
   let currentValue = 0;
 

--- a/src/oomph-visualizer/d3/charts/basic/heat.js
+++ b/src/oomph-visualizer/d3/charts/basic/heat.js
@@ -1,8 +1,8 @@
-export default function createD3Heatmap(data, options, generalElements) {
+export default function createD3Heatmap(data, options, chartComponents) {
   const {
     width, height, margin, colorScale, x = 'x', y = 'y',
   } = options;
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
 
   // Create the x scale, using scaleBand to handle categorical data
   const xScale = d3.scaleBand()

--- a/src/oomph-visualizer/d3/charts/basic/line.js
+++ b/src/oomph-visualizer/d3/charts/basic/line.js
@@ -1,7 +1,7 @@
-export default function createD3LineGraph(data, options, generalElements) {
-  const { x } = generalElements;
-  const { y } = generalElements;
-  const { svg } = generalElements;
+export default function createD3LineGraph(data, options, chartComponents) {
+  const { x } = chartComponents;
+  const { y } = chartComponents;
+  const { svg } = chartComponents;
 
   // Sort the data by the x value if its numerical
   if (typeof data[0].x === 'number') {

--- a/src/oomph-visualizer/d3/charts/basic/pie.js
+++ b/src/oomph-visualizer/d3/charts/basic/pie.js
@@ -1,7 +1,7 @@
-export default function createD3PieChart(data, options, generalElements) {
+export default function createD3PieChart(data, options, chartComponents) {
   const { width } = options;
   const { height } = options;
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
   const radius = Math.min(width, height) / 2;
 
   // Centers the pie chart within the svg element

--- a/src/oomph-visualizer/d3/charts/basic/polar.js
+++ b/src/oomph-visualizer/d3/charts/basic/polar.js
@@ -1,8 +1,8 @@
-export default function createD3PolarChart(data, options, generalElements) {
+export default function createD3PolarChart(data, options, chartComponents) {
   const {
     colors, innerRadius, outerRadius,
   } = options;
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
 
   const x = d3
     .scaleBand()

--- a/src/oomph-visualizer/d3/charts/basic/radar.js
+++ b/src/oomph-visualizer/d3/charts/basic/radar.js
@@ -1,8 +1,8 @@
-export default function createD3RadarChart(data, options, generalElements) {
+export default function createD3RadarChart(data, options, chartComponents) {
   const {
     width, height, colors, maxValue, levels,
   } = options;
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
   const radius = Math.min(width, height) / 2;
 
   const angleSlice = (2 * Math.PI) / data.length;

--- a/src/oomph-visualizer/d3/charts/basic/scatter.js
+++ b/src/oomph-visualizer/d3/charts/basic/scatter.js
@@ -1,7 +1,7 @@
-export default function createD3ScatterPlot(data, options, generalElements) {
-  const { x } = generalElements;
-  const { y } = generalElements;
-  const { svg } = generalElements;
+export default function createD3ScatterPlot(data, options, chartComponents) {
+  const { x } = chartComponents;
+  const { y } = chartComponents;
+  const { svg } = chartComponents;
 
   // Create circles for each data point
   svg.append('g')

--- a/src/oomph-visualizer/d3/charts/basic/stacked.js
+++ b/src/oomph-visualizer/d3/charts/basic/stacked.js
@@ -1,7 +1,7 @@
-export default function createD3StackedBarChart(data, options, generalElements) {
+export default function createD3StackedBarChart(data, options, chartComponents) {
   const {
     x, y, svg,
-  } = generalElements;
+  } = chartComponents;
 
   // Create a color scale using the color scheme provided
   const color = d3.scaleOrdinal()

--- a/src/oomph-visualizer/d3/charts/basic/waterfall.js
+++ b/src/oomph-visualizer/d3/charts/basic/waterfall.js
@@ -1,8 +1,8 @@
 // TODO add negative and positive color change
-export default function createD3WaterfallChart(data, options, generalElements) {
-  const { x } = generalElements;
-  const { y } = generalElements;
-  const { svg } = generalElements;
+export default function createD3WaterfallChart(data, options, chartComponents) {
+  const { x } = chartComponents;
+  const { y } = chartComponents;
+  const { svg } = chartComponents;
 
   svg.append('g')
     .selectAll('rect')

--- a/src/oomph-visualizer/d3/charts/hierarchy/adjacency.js
+++ b/src/oomph-visualizer/d3/charts/hierarchy/adjacency.js
@@ -1,5 +1,5 @@
-export default function createAdjacencyMatrix(data, options, generalElements) {
-  const { svg } = generalElements;
+export default function createAdjacencyMatrix(data, options, chartComponents) {
+  const { svg } = chartComponents;
   const g = svg
     .append('g')
     .attr('transform', `translate(${options.margin.left}, ${options.margin.top})`);

--- a/src/oomph-visualizer/d3/charts/hierarchy/chord.js
+++ b/src/oomph-visualizer/d3/charts/hierarchy/chord.js
@@ -1,4 +1,4 @@
-export default function createChordDiagram(data, options, generalElements) {
+export default function createChordDiagram(data, options, chartComponents) {
   const {
     width,
     height,
@@ -9,7 +9,7 @@ export default function createChordDiagram(data, options, generalElements) {
   } = options;
   const labels = data.pop();
 
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
 
   const chord = d3.chord().padAngle(0.05).sortSubgroups(d3.descending);
 

--- a/src/oomph-visualizer/d3/charts/hierarchy/cloud.js
+++ b/src/oomph-visualizer/d3/charts/hierarchy/cloud.js
@@ -1,7 +1,7 @@
-export default function createWordCloud(data, options, generalElements) {
+export default function createWordCloud(data, options, chartComponents) {
   const { width, height, y2ForceStrength } = options;
   const fontSize = (d) => Math.sqrt(d.value) * 2;
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
   // Create a linear scale for the radius of the bubbles
   const radiusScale = d3.scaleSqrt()
     .domain([0, d3.max(data, (d) => d.value)])

--- a/src/oomph-visualizer/d3/charts/hierarchy/cluster.js
+++ b/src/oomph-visualizer/d3/charts/hierarchy/cluster.js
@@ -1,4 +1,4 @@
-export default function createClusterDiagram(data, options, generalElements) {
+export default function createClusterDiagram(data, options, chartComponents) {
   const {
     width,
     height,
@@ -6,7 +6,7 @@ export default function createClusterDiagram(data, options, generalElements) {
     nodeRadius,
     strokeColor,
   } = options;
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
 
   const cluster = d3.cluster().size([360, height / 2 - 100]);
 

--- a/src/oomph-visualizer/d3/charts/hierarchy/dendogram.js
+++ b/src/oomph-visualizer/d3/charts/hierarchy/dendogram.js
@@ -1,5 +1,5 @@
-export default function createDendrogram(data, options, generalElements) {
-  const { svg } = generalElements;
+export default function createDendrogram(data, options, chartComponents) {
+  const { svg } = chartComponents;
 
   const g = svg
     .append('g')

--- a/src/oomph-visualizer/d3/charts/hierarchy/icicle.js
+++ b/src/oomph-visualizer/d3/charts/hierarchy/icicle.js
@@ -1,9 +1,9 @@
-export default function createIcicleChart(data, options, generalElements) {
+export default function createIcicleChart(data, options, chartComponents) {
   const width = options.width || 960;
   const height = options.height || 500;
 
   const color = d3.scaleOrdinal(d3.schemeCategory10);
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
 
   const partition = (data) => {
     const root = d3.hierarchy(data)

--- a/src/oomph-visualizer/d3/charts/hierarchy/marimekko.js
+++ b/src/oomph-visualizer/d3/charts/hierarchy/marimekko.js
@@ -1,5 +1,5 @@
-export default function createMarimekkoChart(data, options, generalElements) {
-  const { svg } = generalElements;
+export default function createMarimekkoChart(data, options, chartComponents) {
+  const { svg } = chartComponents;
 
   const g = svg
     .append('g')

--- a/src/oomph-visualizer/d3/charts/hierarchy/radial-tree.js
+++ b/src/oomph-visualizer/d3/charts/hierarchy/radial-tree.js
@@ -1,5 +1,5 @@
-export default function createRadialTree(data, options, generalElements) {
-  const { svg } = generalElements;
+export default function createRadialTree(data, options, chartComponents) {
+  const { svg } = chartComponents;
   const g = svg
     .append('g')
     .attr('transform', `translate(${options.width / 2}, ${options.height / 2})`);

--- a/src/oomph-visualizer/d3/charts/hierarchy/sankey.js
+++ b/src/oomph-visualizer/d3/charts/hierarchy/sankey.js
@@ -1,6 +1,6 @@
 import { sankey as d3Sankey, sankeyLinkHorizontal } from 'd3-sankey';
 
-export default function createSankeyDiagram(data, options, generalElements) {
+export default function createSankeyDiagram(data, options, chartComponents) {
   const {
     width,
     height,
@@ -8,7 +8,7 @@ export default function createSankeyDiagram(data, options, generalElements) {
     nodePadding,
   } = options;
   const color = d3.scaleOrdinal(d3.schemeCategory10);
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
 
   svg.append('g');
 

--- a/src/oomph-visualizer/d3/charts/hierarchy/sun.js
+++ b/src/oomph-visualizer/d3/charts/hierarchy/sun.js
@@ -1,10 +1,10 @@
-export default function createD3SunburstChart(data, options, generalElements) {
+export default function createD3SunburstChart(data, options, chartComponents) {
   // Create a color scale
   const color = d3.scaleOrdinal(options.colorScheme);
   const {
     width, height, margin, radius,
   } = options;
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
   // Create a partition layout
   const partition = (data) => {
     const root = d3.hierarchy(data)

--- a/src/oomph-visualizer/d3/charts/hierarchy/tree-diagram.js
+++ b/src/oomph-visualizer/d3/charts/hierarchy/tree-diagram.js
@@ -1,4 +1,4 @@
-export default function createTreeDiagram(data, options, generalElements) {
+export default function createTreeDiagram(data, options, chartComponents) {
   const {
     width,
     height,
@@ -6,7 +6,7 @@ export default function createTreeDiagram(data, options, generalElements) {
     radius,
     strokeColor,
   } = options;
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
 
   const tree = d3.tree().size([height - 10, width - 10]); // Adjust size here
 

--- a/src/oomph-visualizer/d3/charts/hierarchy/tree-map.js
+++ b/src/oomph-visualizer/d3/charts/hierarchy/tree-map.js
@@ -1,9 +1,9 @@
-export default function createD3TreeMap(data, options, generalElements) {
+export default function createD3TreeMap(data, options, chartComponents) {
   // Set default options
   const width = options.width || 600;
   const height = options.height || 400;
   const color = d3.scaleOrdinal(d3.schemeCategory10);
-  const { svg } = generalElements;
+  const { svg } = chartComponents;
 
   // Create the treemap layout
   const treemap = d3.treemap()

--- a/src/oomph-visualizer/d3/charts/hierarchy/voronoi.js
+++ b/src/oomph-visualizer/d3/charts/hierarchy/voronoi.js
@@ -1,7 +1,7 @@
 import { voronoiTreemap } from 'd3-voronoi-treemap';
 
-export default function createVoronoiTreemap(data, options, generalElements) {
-  const { svg } = generalElements;
+export default function createVoronoiTreemap(data, options, chartComponents) {
+  const { svg } = chartComponents;
 
   const layout = voronoiTreemap().size([options.width, options.height]);
 

--- a/src/oomph-visualizer/d3/functions/append-axes.js
+++ b/src/oomph-visualizer/d3/functions/append-axes.js
@@ -1,10 +1,10 @@
-export default function appendAxes(chart, options, generalElements) {
+export default function appendAxes(chart, options, chartComponents) {
   const { width } = options;
   const { height } = options;
   const { margin } = options;
-  const { svg } = generalElements;
-  const { xAxis } = generalElements;
-  const { yAxis } = generalElements;
+  const { svg } = chartComponents;
+  const { xAxis } = chartComponents;
+  const { yAxis } = chartComponents;
   // this will be checked by graph tags in the future
   if (chart === 'POLAR' || chart === 'RADAR' || chart === 'PIE' || chart === 'DONUT' || chart === 'HEATMAP' || chart === 'BUBBLE') return;
   if (!options.updating) {

--- a/src/oomph-visualizer/d3/functions/create-axes.js
+++ b/src/oomph-visualizer/d3/functions/create-axes.js
@@ -1,6 +1,6 @@
 import { createXAxisLine, createYAxisLine } from './axis-lines.js';
 
-export default function generalElementsFunction(data, chart, options) {
+export default function createAxes(data, chart, options) {
   let x;
 
   switch (chart) {

--- a/src/oomph-visualizer/d3/render-legacy/basic.js
+++ b/src/oomph-visualizer/d3/render-legacy/basic.js
@@ -15,7 +15,7 @@ import createStackedBarChart from '../charts/basic/stacked.js';
 import createWaterfallChart from '../charts/basic/waterfall.js';
 
 import appendAxes from '../functions/append-axes.js';
-import createAxes from '../functions/create-xy.js';
+import createAxes from '../functions/create-axes.js';
 import createSVG from '../functions/create-svg.js';
 
 import addAnimation from '../actions/animate/basic/animate-basic.js';
@@ -89,8 +89,8 @@ export default class BasicClass {
   addCharts(type) { // This method probably needs to be refactored
     this.chartArray.push(...type);
     for (let i = 0; i < type.length; i++) {
-      this.createChart[type[i]](this.data, this.options, this.generalElements);
-      appendAxes(this.chartArray[i], this.options, this.generalElements);
+      this.createChart[type[i]](this.data, this.options, this.chartComponents);
+      appendAxes(this.chartArray[i], this.options, this.chartComponents);
     }
   }
 
@@ -99,13 +99,13 @@ export default class BasicClass {
       // Map chart type to chartClass
       this.options[i].chartClass = this.svgTypeMap[this.chartArray[i]];
 
-      if (shouldCreateGeneralElements.call(this, i) || this.options[0].updating) {
-        this.generalElements = createGeneralElements.call(this, i);
+      if (shouldCreateChartComponents.call(this, i) || this.options[0].updating) {
+        this.chartComponents = createChartComponents.call(this, i);
       }
 
       // If not updating, create a new chart instance using current chart type, data, and options
       if (!this.options[0].updating) {
-        this.createChart[this.chartArray[i]](this.data[i], this.options[i], this.generalElements);
+        this.createChart[this.chartArray[i]](this.data[i], this.options[i], this.chartComponents);
       }
 
       applyStyling.call(this, i);
@@ -152,11 +152,11 @@ function applyActions(i) {
       this.selector,
       this.data[i],
       options,
-      this.generalElements,
+      this.chartComponents,
       options.duration
     );
   } else {
-    appendAxes(this.chartArray[i], options, this.generalElements);
+    appendAxes(this.chartArray[i], options, this.chartComponents);
   }
 }
 
@@ -178,15 +178,15 @@ function applyStyling(i) {
   });
 }
 
-function createGeneralElements(i) {
-  const generalElements = createAxes(this.data[i], this.chartArray[i], this.options[i]);
+function createChartComponents(i) {
+  const chartComponents = createAxes(this.data[i], this.chartArray[i], this.options[i]);
   if (!this.options[0].updating) {
-    generalElements.svg = createSVG(this.selector, this.chartArray[i], this.options[i]);
+    chartComponents.svg = createSVG(this.selector, this.chartArray[i], this.options[i]);
   }
-  return generalElements;
+  return chartComponents;
 }
 
-function shouldCreateGeneralElements(i) {
+function shouldCreateChartComponents(i) {
   const isFirstStackedChart = this.options[i].stack && i === 0;
   const isNotUpdating = !this.options[0].updating;
   const isNotStackedChart = !this.options[i].stack;

--- a/src/oomph-visualizer/d3/render-legacy/geographical.js
+++ b/src/oomph-visualizer/d3/render-legacy/geographical.js
@@ -37,18 +37,18 @@ export default class GeographicClass {
           this.options = input.options;
           this.options[i].chartNumber = i;
         }
-        let generalElements;
+        let chartComponents;
         if (this.options[i].stack && i === 0) {
-          generalElements = createAxes(this.input.data[i], chartArray[i], this.options[i]);
-          generalElements.svg = createSVG(this.selector, chartArray[i], this.options[i]);
-          this.generalElements = generalElements;
+          chartComponents = createAxes(this.input.data[i], chartArray[i], this.options[i]);
+          chartComponents.svg = createSVG(this.selector, chartArray[i], this.options[i]);
+          this.chartComponents = chartComponents;
         } else if (!this.options[i].stack) {
-          generalElements = createAxes(this.input.data[i], chartArray[i], this.options[i]);
-          generalElements.svg = createSVG(this.selector, chartArray[i], this.options[i]);
-          this.generalElements = generalElements;
+          chartComponents = createAxes(this.input.data[i], chartArray[i], this.options[i]);
+          chartComponents.svg = createSVG(this.selector, chartArray[i], this.options[i]);
+          this.chartComponents = chartComponents;
         }
         console.log(this.options[i], 'options', this.chartArray[i], 'graph', this.data[i], 'data', this.selector, 'selector');
-        this.createChart[this.chartArray[i]](this.data[i], this.options[i], this.generalElements);
+        this.createChart[this.chartArray[i]](this.data[i], this.options[i], this.chartComponents);
         const options = this.options[i];
         const elements = d3.selectAll(`svg.${svgTypeMap[this.chartArray[i]]} circle, arc, rect, path, line, polygon, node`);
         // eslint-disable-next-line no-loop-func
@@ -72,7 +72,7 @@ export default class GeographicClass {
           relativeNode(this.selector, this.data[i], this.options[i]);
         }
 
-        appendAxes(this.chartArray[i], this.options[i], this.generalElements);
+        appendAxes(this.chartArray[i], this.options[i], this.chartComponents);
       }
     };
     this.iterateCharts();
@@ -81,8 +81,8 @@ export default class GeographicClass {
   addCharts(type) {
     this.chartArray.push(...type);
     for (let i = 0; i < type.length; i++) {
-      this.createChart[type[i]](this.data, this.options, this.generalElements);
-      appendAxes(this.chartArray[i], this.options, this.generalElements);
+      this.createChart[type[i]](this.data, this.options, this.chartComponents);
+      appendAxes(this.chartArray[i], this.options, this.chartComponents);
     }
   }
 

--- a/src/oomph-visualizer/d3/render-legacy/hierarchy.js
+++ b/src/oomph-visualizer/d3/render-legacy/hierarchy.js
@@ -65,13 +65,13 @@ export default class HierarchyClass {
       VORONOI: createVoronoiTreemap,
       WORDCLOUD: createWordCloud,
     };
-    const generalElements = {};
+    const chartComponents = {};
     this.iterateCharts = () => {
       for (let i = 0; i < this.chartArray.length; i++) {
         this.options[i].chartClass = svgTypeMap[this.chartArray[i]];
-        generalElements.svg = createSVG(this.selector, chartArray[i], this.options[i]);
-        console.log(generalElements);
-        this.createChart[this.chartArray[i]](this.input.data[i], this.input.options[i], generalElements);
+        chartComponents.svg = createSVG(this.selector, chartArray[i], this.options[i]);
+        console.log(chartComponents);
+        this.createChart[this.chartArray[i]](this.input.data[i], this.input.options[i], chartComponents);
         const options = this.input.options[i];
         // This is where we add the class and opacity option to the data elements
         const elements = d3.selectAll(`svg.${svgTypeMap[this.chartArray[i]]} circle, arc, rect, path, line, polygon, node`);


### PR DESCRIPTION
To follow logic of `appendAxes`, also renamed createXY to `createAxes`.

To discuss whether term `elements` and `element` should be renamed to `components` and `component` in the following:

- `src/oomph-visualizer/d3/render-legacy/basic.js/`
- `src/oomph-visualizer/d3/render-legacy/geographical.js`
- `src/oomph-visualizer/d3/render-legacy/hierarchy.js`